### PR TITLE
Added backticks to single and double quotes, plus some refactoring

### DIFF
--- a/ExpandSelectionToQuotes.py
+++ b/ExpandSelectionToQuotes.py
@@ -14,41 +14,41 @@ import sublime, sublime_plugin
 # view.run_command("expand_selection_to_quotes")
 
 class ExpandSelectionToQuotesCommand(sublime_plugin.TextCommand):
-    def run(self, edit):
-        double_quotes = list(map(lambda x: x.begin(), self.view.find_all('"')))
-        single_quotes = list(map(lambda x: x.begin(), self.view.find_all("'")))
-        backtick_quotes = list(map(lambda x: x.begin(), self.view.find_all("`")))
+	def run(self, edit):
+		double_quotes = list(map(lambda x: x.begin(), self.view.find_all('"')))
+		single_quotes = list(map(lambda x: x.begin(), self.view.find_all("'")))
+		backtick_quotes = list(map(lambda x: x.begin(), self.view.find_all("`")))
 
-        def search_for_quotes(q_type, quotes):
-            q_size, before, after = False, False, False
+		def search_for_quotes(q_type, quotes):
+			q_size, before, after = False, False, False
 
-            if len(quotes) - self.view.substr(sel).count('"') >= 2:
-                all_before = list(filter(lambda x: x < sel.begin(), quotes))
-                all_after = list(filter(lambda x: x >= sel.end(), quotes))
+			if len(quotes) - self.view.substr(sel).count('"') >= 2:
+				all_before = list(filter(lambda x: x < sel.begin(), quotes))
+				all_after = list(filter(lambda x: x >= sel.end(), quotes))
 
-                if all_before: before = all_before[-1]
-                if all_after: after = all_after[0]
+				if all_before: before = all_before[-1]
+				if all_after: after = all_after[0]
 
-                if all_before and all_after: q_size = after - before
+				if all_before and all_after: q_size = after - before
 
-            return q_size, before, after
+			return q_size, before, after
 
-        def replace_region(start, end):
-            if sel.size() < end-start-2:
-                start += 1; end -= 1
-            self.view.sel().subtract(sel)
-            self.view.sel().add(sublime.Region(start, end))
+		def replace_region(start, end):
+			if sel.size() < end-start-2:
+				start += 1; end -= 1
+			self.view.sel().subtract(sel)
+			self.view.sel().add(sublime.Region(start, end))
 
-        for sel in self.view.sel():
+		for sel in self.view.sel():
 
-            d_size, d_before, d_after = search_for_quotes('"', double_quotes)
-            s_size, s_before, s_after = search_for_quotes("'", single_quotes)
-            b_size, b_before, b_after = search_for_quotes("`", backtick_quotes)
+			d_size, d_before, d_after = search_for_quotes('"', double_quotes)
+			s_size, s_before, s_after = search_for_quotes("'", single_quotes)
+			b_size, b_before, b_after = search_for_quotes("`", backtick_quotes)
 
 
-            if d_size and (not s_size or d_size < s_size) and (not b_size or d_size < b_size):
-                replace_region(d_before, d_after+1)
-            elif s_size and (not d_size or s_size < d_size) and (not b_size or s_size < b_size):
-                replace_region(s_before, s_after+1)
-            elif b_size and (not d_size or b_size < d_size) and (not s_size or b_size < s_size):
-                replace_region(b_before, b_after+1)
+			if d_size and (not s_size or d_size < s_size) and (not b_size or d_size < b_size):
+				replace_region(d_before, d_after+1)
+			elif s_size and (not d_size or s_size < d_size) and (not b_size or s_size < b_size):
+				replace_region(s_before, s_after+1)
+			elif b_size and (not d_size or b_size < d_size) and (not s_size or b_size < s_size):
+				replace_region(b_before, b_after+1)

--- a/ExpandSelectionToQuotes.py
+++ b/ExpandSelectionToQuotes.py
@@ -14,35 +14,41 @@ import sublime, sublime_plugin
 # view.run_command("expand_selection_to_quotes")
 
 class ExpandSelectionToQuotesCommand(sublime_plugin.TextCommand):
-	def run(self, edit):
-		d_quotes = list(map(lambda x: x.begin(), self.view.find_all('"')))
-		s_quotes = list(map(lambda x: x.begin(), self.view.find_all("'")))
+    def run(self, edit):
+        double_quotes = list(map(lambda x: x.begin(), self.view.find_all('"')))
+        single_quotes = list(map(lambda x: x.begin(), self.view.find_all("'")))
+        backtick_quotes = list(map(lambda x: x.begin(), self.view.find_all("`")))
 
-		for sel in self.view.sel():
-			def search_for_quotes(q_type, quotes):
-				q_size, before, after = False, False, False
+        def search_for_quotes(q_type, quotes):
+            q_size, before, after = False, False, False
 
-				if len(quotes) - self.view.substr(sel).count('"') >= 2:
-					all_before = list(filter(lambda x: x < sel.begin(), quotes))
-					all_after = list(filter(lambda x: x >= sel.end(), quotes))
-					
-					if all_before: before = all_before[-1]
-					if all_after: after = all_after[0]
+            if len(quotes) - self.view.substr(sel).count('"') >= 2:
+                all_before = list(filter(lambda x: x < sel.begin(), quotes))
+                all_after = list(filter(lambda x: x >= sel.end(), quotes))
 
-					if all_before and all_after: q_size = after - before
+                if all_before: before = all_before[-1]
+                if all_after: after = all_after[0]
 
-				return q_size, before, after
+                if all_before and all_after: q_size = after - before
 
-			d_size, d_before, d_after = search_for_quotes('"', d_quotes)
-			s_size, s_before, s_after = search_for_quotes("'", s_quotes)
+            return q_size, before, after
 
-			def replace_region(start, end):
-				if sel.size() < end-start-2:
-					start += 1; end -= 1
-				self.view.sel().subtract(sel)
-				self.view.sel().add(sublime.Region(start, end))
+        def replace_region(start, end):
+            if sel.size() < end-start-2:
+                start += 1; end -= 1
+            self.view.sel().subtract(sel)
+            self.view.sel().add(sublime.Region(start, end))
 
-			if d_size and (not s_size or d_size < s_size):
-				replace_region(d_before, d_after+1)
-			elif s_size and (not d_size or s_size < d_size):
-				replace_region(s_before, s_after+1)
+        for sel in self.view.sel():
+
+            d_size, d_before, d_after = search_for_quotes('"', double_quotes)
+            s_size, s_before, s_after = search_for_quotes("'", single_quotes)
+            b_size, b_before, b_after = search_for_quotes("`", backtick_quotes)
+
+
+            if d_size and (not s_size or d_size < s_size) and (not b_size or d_size < b_size):
+                replace_region(d_before, d_after+1)
+            elif s_size and (not d_size or s_size < d_size) and (not b_size or s_size < b_size):
+                replace_region(s_before, s_after+1)
+            elif b_size and (not d_size or b_size < d_size) and (not s_size or b_size < s_size):
+                replace_region(b_before, b_after+1)

--- a/README
+++ b/README
@@ -1,3 +1,3 @@
-Expands selections to the closest containing pairs of single or double quotes.
+Expands selections to the closest containing pairs of single or double quotes or backticks.
 
 The default keybinding is Ctrl+'.


### PR DESCRIPTION
I added the ability to expand to Markdown backticks \` as well as single and double quotes. I also did a little refactoring, moving the function definitions for `search_for_quotes()` and `replace_region()` outside the `for` loop, so new function objects aren't created each time through the loop.

Here's the test I used to make sure the logic was correct:

```python
test_values = [(3, 0, 0), # d_size, s_size, b_size
               (0, 3, 0),
               (0, 0, 3),
               (3, 1, 2),
               (1, 3, 2),
               (1, 2, 3),
               (3, 2, 1),
               (2, 3, 1),
               (2, 1, 3),
               ]

for values in test_values:
    d_size, s_size, b_size = values
    print(values)
    if d_size and (not s_size or d_size < s_size) and (not b_size or d_size < b_size):
        print("d block is True")
    else: print("d block is False")
    if s_size and (not d_size or s_size < d_size) and (not b_size or s_size < b_size):
        print("s block is True")
    else: print("s block is False")
    if b_size and (not d_size or b_size < d_size) and (not s_size or b_size < s_size):
        print("b block is True")
    else: print("b block is False")
```
It should be `True` where there's a 3, and `False` everywhere else.

Let me know if you have any questions.